### PR TITLE
Add basic Node.js booking server and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "minotawrik",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,97 @@
+const http = require('http');
+const { URL } = require('url');
+const { randomUUID } = require('crypto');
+
+function createServer() {
+  const bookings = [];
+
+  return http.createServer(async (req, res) => {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+
+    if (req.method === 'GET' && url.pathname === '/bookings') {
+      const boxId = url.searchParams.get('boxId');
+      const date = url.searchParams.get('date'); // YYYY-MM-DD
+
+      let result = bookings;
+      if (boxId) result = result.filter(b => b.boxId === boxId);
+      if (date) result = result.filter(b => b.start.startsWith(date));
+
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify(result));
+    }
+
+    if (req.method === 'POST' && url.pathname === '/bookings') {
+      const body = await readBody(req);
+      const { boxId, start, end } = body;
+      const startDate = new Date(start);
+      const endDate = new Date(end);
+
+      const conflict = bookings.some(b => b.boxId === boxId &&
+        !(endDate <= new Date(b.start) || startDate >= new Date(b.end)));
+
+      if (conflict) {
+        res.writeHead(409);
+        return res.end('Conflict');
+      }
+
+      const booking = { id: randomUUID(), boxId, start, end };
+      bookings.push(booking);
+
+      res.writeHead(201, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify(booking));
+    }
+
+    if (req.method === 'PATCH' && url.pathname.startsWith('/bookings/')) {
+      const id = url.pathname.split('/')[2];
+      const body = await readBody(req);
+      const booking = bookings.find(b => b.id === id);
+      if (!booking) {
+        res.writeHead(404);
+        return res.end('Not Found');
+      }
+      if (body.boxId) booking.boxId = body.boxId;
+      if (body.start) booking.start = body.start;
+      if (body.end) booking.end = body.end;
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify(booking));
+    }
+
+    if (req.method === 'DELETE' && url.pathname.startsWith('/bookings/')) {
+      const id = url.pathname.split('/')[2];
+      const index = bookings.findIndex(b => b.id === id);
+      if (index === -1) {
+        res.writeHead(404);
+        return res.end('Not Found');
+      }
+      bookings.splice(index, 1);
+      res.writeHead(204);
+      return res.end();
+    }
+
+    res.writeHead(404);
+    res.end('Not Found');
+  });
+}
+
+async function readBody(req) {
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(chunk);
+  }
+  const data = Buffer.concat(chunks).toString() || '{}';
+  try {
+    return JSON.parse(data);
+  } catch {
+    return {};
+  }
+}
+
+module.exports = { createServer };
+
+if (require.main === module) {
+  const server = createServer();
+  const port = process.env.PORT || 3000;
+  server.listen(port, () => {
+    console.log(`Server running on port ${port}`);
+  });
+}

--- a/server.test.js
+++ b/server.test.js
@@ -1,0 +1,65 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { createServer } = require('./server');
+
+function startServer() {
+  return new Promise(resolve => {
+    const server = createServer();
+    server.listen(0, () => {
+      const port = server.address().port;
+      resolve({ server, port });
+    });
+  });
+}
+
+test('booking flow', async () => {
+  const { server, port } = await startServer();
+  const base = `http://localhost:${port}`;
+
+  // Create booking
+  let res = await fetch(`${base}/bookings`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      boxId: 'A',
+      start: '2024-01-01T10:00',
+      end: '2024-01-01T11:00'
+    })
+  });
+  assert.strictEqual(res.status, 201);
+  const created = await res.json();
+
+  // Attempt conflicting booking
+  res = await fetch(`${base}/bookings`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      boxId: 'A',
+      start: '2024-01-01T10:30',
+      end: '2024-01-01T11:30'
+    })
+  });
+  assert.strictEqual(res.status, 409);
+
+  // Fetch bookings
+  res = await fetch(`${base}/bookings?boxId=A&date=2024-01-01`);
+  const list = await res.json();
+  assert.strictEqual(list.length, 1);
+  assert.strictEqual(list[0].id, created.id);
+
+  // Update booking
+  res = await fetch(`${base}/bookings/${created.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ end: '2024-01-01T12:00' })
+  });
+  assert.strictEqual(res.status, 200);
+  const updated = await res.json();
+  assert.strictEqual(updated.end, '2024-01-01T12:00');
+
+  // Delete booking
+  res = await fetch(`${base}/bookings/${created.id}`, { method: 'DELETE' });
+  assert.strictEqual(res.status, 204);
+
+  server.close();
+});


### PR DESCRIPTION
## Summary
- implement minimal HTTP booking server with in-memory storage and conflict checks
- cover booking creation, retrieval, update, and deletion via node:test suite

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a49adfed4c8328a68989beca7082e8